### PR TITLE
chore: update README.md for no longer being archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-**NOTICE**: this repo has been archived and left for historical reference but
-is no longer maintained.
-
 # InfluxDB Templates
 
-This repo is a collection of [templates](https://v2.docs.influxdata.com/v2.0/visualize-data/templates/) used in the InfluxDB UI.
+This repo is a collection of [templates](https://v2.docs.influxdata.com/v2.0/visualize-data/templates/) used in the InfluxDB 2.x UI.
 
 ## Development
 


### PR DESCRIPTION
This repo is a dependency of influxdb2 and therefore should not be archived. This does add maintenance for its node packages wrt dependabot, but we'll use dependabot rules to help with the devDependencies.